### PR TITLE
Have to pin setuptools version, maintainers removed pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools 
+setuptools==81.0.0
 wheel
 six
 warcio>=1.7.5


### PR DESCRIPTION
Because pkg_resources has been deprecated, we have to pin setuptools version. 

See https://setuptools.pypa.io/en/stable/history.html#v82-0-0